### PR TITLE
provide feedback on why file could not be opened

### DIFF
--- a/lib/Log/Log4perl/Config.pm
+++ b/lib/Log/Log4perl/Config.pm
@@ -629,7 +629,7 @@ sub config_read {
             }
         }else{
             print "Reading config from file '$config'\n" if _INTERNAL_DEBUG;
-            open FILE, "<$config" or die "Cannot open config file '$config'";
+            open FILE, "<$config" or die "Cannot open config file '$config' - $!";
             print "Reading ", -s $config, " bytes.\n" if _INTERNAL_DEBUG;
             config_file_read(\*FILE, \@text);
             close FILE;


### PR DESCRIPTION
As it stands, a failed open call in Config.pm does not tell the user/programmer why the open failed.

I added the output of $! to the error message to remedy this.
