### PR TITLE
Fix for RT#62674

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 ##################################################
  Revision history for Log::Log4perl
 ##################################################
+1.32 (not yet released)
+   *         [RT 62674] Fixed call to deprecated form of UNIVERSAL::can (Karen
+             Etheridge).
 
 1.31 (2010/10/27)
   *     (ms) Fixed the number of skipped tests for Windows for previous fix

--- a/lib/Log/Log4perl/Appender.pm
+++ b/lib/Log/Log4perl/Appender.pm
@@ -47,29 +47,9 @@ sub new {
         # Check if the class/package is already available because
         # something like Class::Prototyped injected it previously.
 
-           # Can we use UNIVERSAL to check the appender's new() method?
-           # [RT 28987]
-        my $use_universal;
-        {
-          no strict 'refs';
-          if(scalar(keys %{"UNIVERSAL\::"})) {
-              $use_universal = 1;
-          }
-        }
-
-        my $module_loaded;
-
-        if($use_universal) {
-           if( UNIVERSAL::can($appenderclass, 'new') ) {
-               $module_loaded = 1;
-           }
-        } else {
-           if(scalar(keys %{"$appenderclass\::"})) {
-               $module_loaded = 1;
-           }
-        }
-
-        if( !$module_loaded ) {
+        # Use UNIVERSAL::can to check the appender's new() method
+        # [RT 28987]
+        if( ! $appenderclass->can('new') ) {
             # Not available yet, try to pull it in.
             # see 'perldoc -f require' for why two evals
             eval "require $appenderclass";


### PR DESCRIPTION
Thanks to the installation of UNIVERSAL::can (http://search.cpan.org/~chromatic/UNIVERSAL-can-1.16/lib/UNIVERSAL/can.pm), I got a warning from Log::Log4perl::Appender about an inappropriate/ill-advised call to the function form of can(). I've fixed this in the supplied patch, and removed some unnecessary checks that will always succeed for all versions of Perl that this module permits (I've checked the docs back to perl5.005).
