### PR TITLE
for qw() {} deprecated

### DIFF
--- a/t/003Layout-Rr.t
+++ b/t/003Layout-Rr.t
@@ -55,7 +55,7 @@ $logger->warn("End");
 #  Debug traces to be turned on when troubleshooting
 if ($DEBUG) {
     # Get the contents of the buffers
-    foreach my $appender qw(A B) {
+    foreach my $appender (qw(A B)) {
         my $buffer = Log::Log4perl::Appender::TestBuffer->by_name($appender)->buffer();
         diag("========= $appender ==========");
         diag($buffer);


### PR DESCRIPTION
This fixes the deprecation messages generated in the test suite when using bare qw() in a for loop
