### PR TITLE
Third example in POD does not work

### DIFF
--- a/lib/Log/Log4perl.pm
+++ b/lib/Log/Log4perl.pm
@@ -1118,7 +1118,7 @@ category, using the format defined for it.
 
 Third example:
 
-    log4j.rootLogger=debug, stdout, R
+    log4j.rootLogger=DEBUG, stdout, R
     log4j.appender.stdout=org.apache.log4j.ConsoleAppender
     log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
     log4j.appender.stdout.layout.ConversionPattern=%5p (%F:%L) - %m%n


### PR DESCRIPTION
If you copy/paste the 3rd example in the POD you get:

level 'debug' is not a valid error level (DEBUG|INFO|WARN|ERROR|FATAL|TRACE|ALL|OFF) at C:/strawberry/perl/site/lib/Log/Log4perl/Config.pm line 276

because `debug` is not capitalized there. this patch addresses that.
