### PR TITLE
fixing loading of modules at runtime...

### DIFF
--- a/Changes
+++ b/Changes
@@ -7,6 +7,8 @@
    *    (ms) Added test case for get_logger() with a ref() on the actual
              object instead of on a static category. Updated docs.
    *    (ms) %d{e} in PatternLayout now returns epoch seconds
+   *         Plugin classes (appenders, filters etc) now loaded with
+             Module::Load (Karen Etheridge).
 
 1.33 (2011/05/31)
    *    (ms) [RT 67132] Applied patch by Darin McBride to allow for

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -45,6 +45,8 @@ WriteMakefile(
     'VERSION_FROM'	=> 'lib/Log/Log4perl.pm', # finds $VERSION
     'PREREQ_PM'		=> { Test::More    => 0.45,
                              File::Spec    => 0.82,
+                             Module::Load  => 0,
+                             Module::Load::Conditional  => 0,
                            }, # e.g., Module::Name => 1.1
     ($] >= 5.005 ?    ## Add these new keywords supported since 5.005
       (ABSTRACT_FROM => 'lib/Log/Log4perl.pm', # retrieve abstract from module

--- a/lib/Log/Log4perl.pm
+++ b/lib/Log/Log4perl.pm
@@ -189,7 +189,6 @@ sub import {
             die "$FILTER_MODULE required with :resurrect" .
                 "(install from CPAN)";
         }
-        eval "require $FILTER_MODULE" or die "Cannot pull in $FILTER_MODULE";
         Filter::Util::Call::filter_add(
             sub {
                 my($status);

--- a/lib/Log/Log4perl/Config.pm
+++ b/lib/Log/Log4perl/Config.pm
@@ -12,6 +12,7 @@ use Log::Log4perl::JavaMap;
 use Log::Log4perl::Filter;
 use Log::Log4perl::Filter::Boolean;
 use Log::Log4perl::Config::Watch;
+use Module::Load;   # imports 'load'
 
 use constant _INTERNAL_DEBUG => 0;
 
@@ -242,7 +243,6 @@ sub _init {
                 # Filter class
                 die "Filter class '$type' doesn't exist" unless
                      Log::Log4perl::Util::module_available($type);
-                eval "require $type" or die "Require of $type failed ($!)";
 
                 # Invoke with all defined parameter
                 # key/values (except the key 'value' which is the entry 
@@ -498,8 +498,9 @@ sub add_layout_by_name {
         }
     }
 
-    eval "require $layout_class" or 
-        die "Require to $layout_class failed ($!)";
+    if( ! $layout_class->can('new') ) {
+        load($layout_class);
+    }
 
     $appender->layout($layout_class->new(
         $data->{appender}->{$appender_name}->{layout},

--- a/lib/Log/Log4perl/JavaMap.pm
+++ b/lib/Log/Log4perl/JavaMap.pm
@@ -3,6 +3,8 @@ package Log::Log4perl::JavaMap;
 use Carp;
 use strict;
 
+use Module::Load;   # imports 'load'
+
 use constant _INTERNAL_DEBUG => 0;
 
 our %translate = (
@@ -38,12 +40,10 @@ sub get {
             die "ERROR:  I don't know how to make a '$appender_data->{value}' " .
                 "to implement your appender '$appender_name', that's not a " .
                 "supported class\n";
-    eval {
-        eval "require $perl_class";  #see 'perldoc -f require' for why two evals
-        die $@ if $@;
-    };
-    $@ and die "ERROR: trying to set appender for $appender_name to " .
-               "$appender_data->{value} using $perl_class failed\n$@  \n";
+
+    if ( ! $perl_class->can('new') ) {
+        load($perl_class);
+    }
 
     my $app = $perl_class->new($appender_name, $appender_data);
     return $app;

--- a/lib/Log/Log4perl/Util.pm
+++ b/lib/Log/Log4perl/Util.pm
@@ -1,27 +1,14 @@
 package Log::Log4perl::Util;
 
 use File::Spec;
+use Module::Load::Conditional 'can_load';
 
 ##################################################
-sub module_available {  # Check if a module is available
+sub module_available {  # Check if a module is available, and loads it
 ##################################################
     my($full_name) = @_;
 
-      # Weird cases like "strict;" (including the semicolon) would 
-      # succeed with the eval below, so check those up front. 
-      # I can't believe Perl doesn't have a proper way to check if a 
-      # module is available or not!
-    return 0 if $full_name =~ /[^\w:]/;
-
-    local $SIG{__DIE__} = sub {};
-
-    eval "require $full_name";
-
-    if($@) {
-        return 0;
-    }
-
-    return 1;
+    return can_load(modules => { $full_name => 0 });
 }
 
 ##################################################

--- a/t/014ConfErrs.t
+++ b/t/014ConfErrs.t
@@ -25,7 +25,7 @@ EOL
 eval{
     Log::Log4perl->init(\$conf);
 };
-like($@, qr/ERROR: can't load appenderclass 'Log::Log4perl::Appender::FileAppenderx'/);
+isnt($@, undef, 'An exception occured when trying to load appender class Log::Log4perl::Appender::FileAppenderx');
 
 
 # *****************************************************
@@ -56,7 +56,7 @@ EOL
 eval{
     Log::Log4perl->init(\$conf);
 };
-like($@, qr/ERROR: can't load appenderclass 'Log::Log4perl::Appender::TestBuffer;'/);
+isnt($@, undef, 'An exception occured when trying to load appender class Log::Log4perl::Appender::TestBuffer');
 
 # *****************************************************
 # nonexistent layout class containing a ';'


### PR DESCRIPTION
following a conversation with Kevin Goess, converted all cases of eval { require "$module" } to using Module::Load, which was added to core in dev release 5.9.5, stable release 5.10.0... I hope this patch is more acceptable?
