### PR TITLE
unlink t/tmp/log4perltest prior to DBI connection

### DIFF
--- a/t/034DBI.t
+++ b/t/034DBI.t
@@ -214,9 +214,10 @@ $dbh->disconnect;
 # might as well give it a thorough check
 Log::Log4perl->reset;
 
-$dbh = DBI->connect('DBI:CSV:f_dir=t/tmp','testuser','testpw',{ PrintError => 1 });
+unlink 't/tmp/log4perltest'
+    if -e 't/tmp/log4perltest';
 
-$dbh->do('DROP TABLE log4perltest') if -e 't/tmp/log4perltest';
+$dbh = DBI->connect('DBI:CSV:f_dir=t/tmp','testuser','testpw',{ PrintError => 1 });
 
 $stmt = <<EOL;
     CREATE TABLE log4perltest (


### PR DESCRIPTION
This appears to be interacting weirdly with the latest SQL::Statement and 
DBD::CSV, so let's get rid of it before getting into our tests.
