### PR TITLE
support for ";!" as comment delimiters

### DIFF
--- a/lib/Log/Log4perl/Config.pm
+++ b/lib/Log/Log4perl/Config.pm
@@ -975,8 +975,25 @@ The format is the same as the one as used for C<log4j>, just with
 a few perl-specific extensions, like enabling the C<Bar::Twix>
 syntax instead of insisting on the Java-specific C<Bar.Twix>.
 
-Comment lines (starting with arbitrary whitespace and a #) and
-blank lines (all whitespace or empty) are ignored.
+Comment lines and blank lines (all whitespace or empty) are ignored.
+
+Comment lines may start with arbitrary whitespace followed by one of:
+
+=over 4
+
+=item # - Common comment delimiter
+
+=item ! - Java .properties file comment delimiter accepted by log4j
+
+=item ; - Common .ini file comment delimiter
+
+=back
+
+Comments at the end of a line are not supported. So if you write
+
+    log4perl.appender.A1.filename=error.log #in current dir
+
+you will find your messages in a file called C<error.log #in current dir>.
 
 Also, blanks between syntactical entities are ignored, it doesn't 
 matter if you write

--- a/lib/Log/Log4perl/Config/PropertyConfigurator.pm
+++ b/lib/Log/Log4perl/Config/PropertyConfigurator.pm
@@ -32,7 +32,7 @@ sub parse {
 
     while (@$text) {
         local $_ = shift @$text;
-        s/^\s*#.*//;
+        s/^\s*[#;!].*//;
         next unless /\S/;
     
         my @parts = ();
@@ -41,7 +41,7 @@ sub parse {
             my $prev = $1;
             my $next = shift(@$text);
             $next =~ s/^ +//g;  #leading spaces
-            $next =~ s/^#.*//;
+            $next =~ s/^[#;!].*//;
             $_ = $prev. $next;
             chomp;
         }

--- a/t/004Config.t
+++ b/t/004Config.t
@@ -14,7 +14,7 @@ BEGIN {
 # change 'tests => 1' to 'tests => last_test_to_print';
 #########################
 use Test::More;
-BEGIN { plan tests => 26 };
+BEGIN { plan tests => 28 };
 
 use Log::Log4perl;
 use Log::Log4perl::Appender::TestBuffer;
@@ -383,3 +383,24 @@ log4j.appender.A1.layout.ConversionPattern = object%m%n
 eval { Log::Log4perl->init( \$conf ); };
 
 is $@, "", "'trigger' category [rt.cpan.org #50495]";
+
+######################################################################
+# Test alternate comment syntax
+######################################################################
+
+$conf = <<'END_CONF';
+log4perl.MyParam = MyVal
+; log4perl.MyParam = AnotherVal
+END_CONF
+
+eval { Log::Log4perl->init( \$conf ); };
+is $@, "", "support semi-colon comment character [github.com #24]";
+
+$conf = <<'END_CONF';
+log4perl.MyParam = MyVal
+! log4perl.MyParam = AnotherVal
+END_CONF
+
+eval { Log::Log4perl->init( \$conf ); };
+is $@, "", "support exclamation comment character [github.com #24]";
+


### PR DESCRIPTION
This addresses issue https://github.com/mschilli/log4perl/issues/24 which I submitted.

Tests and documentation updated as well. If this pull request should go to another branch let me know.
