### PR TITLE
Set Term::ANSIColor::EACHLINE

### DIFF
--- a/lib/Log/Log4perl/Appender/ScreenColoredLevels.pm
+++ b/lib/Log/Log4perl/Appender/ScreenColoredLevels.pm
@@ -10,6 +10,10 @@ use strict;
 use Term::ANSIColor qw();
 use Log::Log4perl::Level;
 
+BEGIN {
+    $Term::ANSIColor::EACHLINE="\n";
+}
+
 ##################################################
 sub new {
 ##################################################


### PR DESCRIPTION
Set the EACHLINE package variable for Term::ANSIColor to "\n" so that
the color code will be reset at the end of each line and not pollute the
next line in the terminal.
