### PR TITLE
Added PatternLayout for intended multiline logging.

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -64,6 +64,7 @@ lib/Log/Log4perl/Layout.pm
 lib/Log/Log4perl/Layout/NoopLayout.pm
 lib/Log/Log4perl/Layout/PatternLayout.pm
 lib/Log/Log4perl/Layout/PatternLayout/Multiline.pm
+lib/Log/Log4perl/Layout/PatternLayout/MultilineIndented.pm
 lib/Log/Log4perl/Layout/SimpleLayout.pm
 lib/Log/Log4perl/Level.pm
 lib/Log/Log4perl/Logger.pm
@@ -148,6 +149,7 @@ t/064RealClass.t
 t/065Undef.t
 t/066SQLite.t
 t/067Exception.t
+t/068MultilineIndented.t
 t/compare.pl
 t/deeper1.expected
 t/deeper6.expected

--- a/lib/Log/Log4perl/Layout/PatternLayout/MultilineIndented.pm
+++ b/lib/Log/Log4perl/Layout/PatternLayout/MultilineIndented.pm
@@ -1,0 +1,160 @@
+#!/usr/bin/perl
+
+package Log::Log4perl::Layout::PatternLayout::MultilineIndented;
+
+use base qw(Log::Log4perl::Layout::PatternLayout); 
+
+# find the position of last occurrence of a substring
+# within a string
+
+# using an anonymous sub to make it inaccessible from outside
+# very private ;-)
+
+my $find_last_pos = sub {               
+    my ($str, $substr) = @_;
+    my $last_pos;
+
+    return undef if ! defined $str || ! defined $substr;
+
+    return 0 if $substr eq '';
+
+    my $pos = 0;
+    my $len_substr = length($substr);
+    while ( ($pos = index($str, $substr, $pos)) != -1 ) {
+        $last_pos = $pos;
+        $pos += $len_substr;
+    }
+    return $last_pos;
+};
+
+
+# render the output of a multiline log message
+
+###########################################
+sub render {
+###########################################
+    my($self, $message, $category, $priority, $caller_level) = @_; 
+
+    my @lines = split /\r?\n/, $message; 
+    $caller_level = 0 unless defined $caller_level; 
+    my $result = ''; 
+
+    return $result if scalar @lines == 0;
+
+    # full rendering/formatting for first line
+    my $first_msg = shift @lines;
+    $result .= $self->SUPER::render( $first_msg, $category, $priority, $caller_level + 1 ); 
+
+    if ( scalar @lines ) {
+        # for all lines following we override all characters before of the message
+        # provided by the user (usually date, category ...) by blanks
+        my $indent_pos = $find_last_pos->($result, $first_msg);
+        my $rendered_line; 
+        my $blanks = ' ' x $indent_pos;
+        for my $line ( @lines ) { 
+            $rendered_line = $self->SUPER::render( $line, $category, $priority, $caller_level + 1 ); 
+
+            # replace characters up to $indent_pos with blanks
+            substr($rendered_line, 0, $indent_pos, $blanks);
+
+            $result .= $rendered_line;
+        }
+    }
+    return $result; 
+} 
+
+1; 
+
+__END__
+
+= head1 NAME
+
+    Logger::Layout::PatternLayout::MultilineIndented
+
+=head1 SYNOPSIS
+
+    use Logger::Layout::PatternLayout::MultilineIndented;
+
+    my $layout = Logger::Layout::PatternLayout::MultilineIndented->new("%d > %m %n");
+
+    NOTE: you have to set %n for the layout.
+
+=head1 DESCRIPTION
+
+C<Logger::Layout::PatternLayout::MultilineIndented> is a subclass
+of Log4perl's PatternLayout and is helpful if you send multiline
+messages to your appenders which normally appear as
+
+    2007/04/04 23:59:01 > This is
+    a message with
+    multiple lines
+
+and you want them to appear as 
+
+    2007/04/04 23:59:01 > This is
+                          a message with
+                          multiple lines
+
+This layout class is like C<Logger::Layout::PatternLayout::Multiline> 
+It simply splits up the incoming message into
+several lines by line breaks. It renders the first line of the message 
+with the given PatternLayout and indents the following lines properly.
+
+=head1 HOW IT WORKS and a CAVEAT
+
+The algorithm is very simple. 
+The first line is rendered according to the pattern you provided. 
+The rendered result string is used to calculate the last position 
+of the provided first line in the rendered result string. 
+All following lines are rendered too, but in a second step all characters 
+up to the calculated position are replaced by blanks and the result is output.
+
+The Caveat :
+
+If your pattern is "%d > %m This is%n" and you log
+
+    $logger->info(<<'EOF_MSG');
+    This is
+    a message with
+    multiple lines
+    EOF_MSG
+
+the last position of the first message line 'This is' is searched
+within the first rendered result line, which is 
+
+    "2013/05/02 14:40:24 > This is This is\n"
+                                   |
+                                 last position of first message line 
+The next rendered line would be
+
+    "2013/05/02 14:40:24 > a message with This is\n"
+                                   |
+                                last position of first message line 
+
+and all characters up to the last position of the first message line
+will be replaced by blanks.
+
+    "                              e with This is\n"
+                                   |
+                                 last position of first message line 
+                                   
+
+In your log file appears
+
+    2013/07/30 18:04:00 > This is This is
+                                  e with This is
+                                   lines This is
+
+Usually %m is the last item in your layout pattern and the position of the
+message in the rendered output line can be determined without problems, 
+so it should not be an issue in most cases.
+
+
+
+
+=head1 LICENSE
+
+Copyright 2002-2013 by Wolfgang Pecho E<lt>wolfgang_pecho@gmx.deE<gt>.
+
+This library is free software; you can redistribute it and/or modify
+it under the same terms as Perl itself. 

--- a/t/068MultilineIndented.t
+++ b/t/068MultilineIndented.t
@@ -1,0 +1,77 @@
+
+use Log::Log4perl;
+use Log::Log4perl::Appender;
+use Log::Log4perl::Appender::File;
+use Log::Log4perl::Layout::PatternLayout::MultilineIndented;
+
+use Test::More tests => 1;
+
+my $logger = Log::Log4perl->get_logger("blah");
+
+#      1                 19
+#      |                 |
+# %d : yyyy/mm/dd hh:mm:ss
+my $layout = Log::Log4perl::Layout::PatternLayout::MultilineIndented->new("%d > %m%n");
+
+my $logfile = "./file.log";
+
+my $appender = Log::Log4perl::Appender->new(
+               "Log::Log4perl::Appender::File",
+                    name => 'foo',
+                    filename  => './file.log',
+                    mode      => 'append',
+                    autoflush => 1,
+               );
+
+# Set the appender's layout
+$appender->layout($layout);
+$logger->add_appender($appender);
+
+my $msg =<<"EOF_MSG";
+This is
+a message with
+multiple lines
+EOF_MSG
+
+chomp($msg);
+
+$appender->log({ level => 1, message => $msg }, 'foo_category', 'INFO');
+
+my $err_str = check_log_file_format($logfile);
+my $test_name = 'log file has multiline intended format' . ($err_str ? " - reason : $err_str" : "");
+ok ( ! $err_str, $test_name );
+
+
+unlink $logfile;
+
+
+sub check_log_file_format {
+    my $logfile = shift;
+    
+    my $err_str = "";
+    my $line_count = 1;
+    open(my $fh, "<", $logfile) || return "could not open log file '$logfile'";
+
+    for my $line (<$fh>) {
+        if ($line_count == 1) {
+            # 1                 19 
+            # |                 |
+            # yyyy/mm/dd hh:mm:ss > %m
+            unless ( $line =~ m!^\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2} > This is\s*$! ) {
+                $err_str = "first line wrong, should be: yyyy/mm/dd hh::mm::ss This is" ;        
+                last;
+            }
+        }
+        else {
+            unless ( $line =~ /^ {22}\S/ ) {
+                $err_str = "format of line $line_count wrong";
+                last;
+            }
+        }
+        $line_count++;
+    }
+
+    close($fh);
+
+    return $err_str;
+}


### PR DESCRIPTION
Added Log::Log4perl::Layout::PatternLayout::MultilineIndented and a test for it 
to have a layout for logging this way :

```
2013/07/30 21:57:42 > This is
                      a message with
                      multiple lines
```

Sorry, second and third line of log message should be indented properly. Do not know how to do for a comment.
Edit: Got it ;-)
