### PR TITLE
avoid deep recursion on win32 (rt#84818)

### DIFF
--- a/lib/Log/Log4perl/Resurrector.pm
+++ b/lib/Log/Log4perl/Resurrector.pm
@@ -45,6 +45,12 @@ sub resurrector_loader {
 
     print "resurrector_loader called with $module\n" if INTERNAL_DEBUG;
 
+      # Skip Win32.pm to avoid infinite recursion
+    if($module eq 'Win32.pm') {
+        print "Ignoring Win32.pm\n" if INTERNAL_DEBUG;
+        return undef;
+    }
+    
       # Skip Log4perl appenders
     if($module =~ m#^Log/Log4perl/Appender#) {
         print "Ignoring $module (Log4perl-internal)\n" if INTERNAL_DEBUG;


### PR DESCRIPTION
This seems to fix t/053Resurrect.t for me on Windows.  The only downside that I can think of to this patch is if someone wants to use the resurrector on their own Win32.pm.  Another fix might be to ensure that tempfile is called before the @INC hook is created.

resurrector_loader is calling resurrector_fh
resurrector_fh is calling File::Temp::tempfile
File::Temp::tempfile must be trying to use/require Win32
use/require Win32 is calling resurrector_loader
