### PR TITLE
avoid recursion generally (rt#84818)

### DIFF
--- a/lib/Log/Log4perl/Resurrector.pm
+++ b/lib/Log/Log4perl/Resurrector.pm
@@ -53,7 +53,7 @@ sub resurrector_loader {
         return undef;
     }
     
-    $resurrecting = $module;
+    local $resurrecting = $module;
     
     
       # Skip Log4perl appenders


### PR DESCRIPTION
This is an alternate to #34 for rt#84818

This is specifically to fix resurrector on windows (with recent File::Temp) where:

resurrector_loader is calling resurrector_fh
resurrector_fh is calling File::Temp::tempfile
File::Temp::tempfile must be trying to use/require Win32
use/require Win32 is calling resurrector_loader

but it should prevent most simple recursion as well.
