### PR TITLE
fix catalyst's abort of so work

### DIFF
--- a/lib/Log/Log4perl/Catalyst.pm
+++ b/lib/Log/Log4perl/Catalyst.pm
@@ -125,13 +125,14 @@ sub _flush {
         next if $appender->{name} !~ /_$CATALYST_APPENDER_SUFFIX$/;
 
         if ($self->abort) {
-            $self->abort(undef);
             $appender->{appender}{buffer} = [];
         }
         else {
             $appender->flush();
         }
     }
+
+    $self->abort(undef);
 }
 
 ##################################################


### PR DESCRIPTION
Hello.

I've tried the Log::Log4perl::Catalyst, but it does not seem to work well.
Catalyst::Plugin::Static::Simple has been using the $c->log->abort(1), but since this is not work, it does not hide.

I tried to write a patch.
I was compared to http://cpansearch.perl.org/src/VANSTYN/Catalyst-Runtime-5.90071/lib/Catalyst/Log.pm

Thank you merge if there is no problem.

Cheers,
Tomohiro Hosaka
