### PR TITLE
fix test for utcDateTimes

### DIFF
--- a/t/070UTCDate.t
+++ b/t/070UTCDate.t
@@ -15,7 +15,21 @@ use strict;
 
 use Test::More;
 
-BEGIN { plan tests => 2 }
+sub zero_offset { return( (join '-',gmtime) eq (join '-',localtime) ) }
+
+BEGIN {
+    my $zero_offset = zero_offset;
+    if ($zero_offset) {
+        $ENV{TZ}='UTC+3';
+        $zero_offset = zero_offset;
+    }
+    if ($zero_offset) {
+        plan skip_all => "gmtime and localtime are the same, can't test";
+    }
+    else {
+        plan tests => 2;
+    }
+}
 
 use Log::Log4perl qw(get_logger);
 use Log::Log4perl::Appender::TestBuffer;


### PR DESCRIPTION
it failed on machines where the local timezone has 0 offset from GMT (e.g. in the UK for half the year)

now, if we detect a 0 offset, we try to force a non-GMT timezone, and skip the test if that's not enough
