### PR TITLE
[rt 107121] Check namespace availability before trying to load modules

### DIFF
--- a/lib/Log/Log4perl/Util.pm
+++ b/lib/Log/Log4perl/Util.pm
@@ -39,6 +39,9 @@ sub module_available {  # Check if a module is available
 ##################################################
     my($full_name) = @_;
 
+    # Proper way to check if a module is available or not
+    return 1 if   exists $main::{ $full_name };
+
       # Weird cases like "strict;" (including the semicolon) would 
       # succeed with the eval below, so check those up front. 
       # I can't believe Perl doesn't have a proper way to check if a 
@@ -47,6 +50,7 @@ sub module_available {  # Check if a module is available
 
     local $SIG{__DIE__} = sub {};
 
+    # We can try to load it, if it is not avaiable yet
     eval "require $full_name";
 
     if($@) {


### PR DESCRIPTION
When layout defined inside your program like
{
    package MyLayout;
    ...
}

You can not use it in config file:

    log4perl.appender.SomeAPP.layout = MyLayout