### PR TITLE
treat msys same as cygwin and MSWin32

### DIFF
--- a/t/lib/Log4perlInternalTest.pm
+++ b/t/lib/Log4perlInternalTest.pm
@@ -18,7 +18,8 @@ our %MINVERSION = qw(
 # check if we're on non-unixy system
 sub is_like_windows {
     if( $^O eq "MSWin32" or
-        $^O eq "cygwin" ) {
+        $^O eq "cygwin"  or
+        $^O eq "msys" ) {
         return 1;
     }
 


### PR DESCRIPTION
This allows Log::Log4perl to install on MSYS2 which is an environment very similar to cygwin.