### PR TITLE
Remove circular depency in Log::Log4perl::Appender

### DIFF
--- a/lib/Log/Log4perl/Appender.pm
+++ b/lib/Log/Log4perl/Appender.pm
@@ -6,7 +6,6 @@ use 5.006;
 use strict;
 use warnings;
 
-use Log::Log4perl::Config;
 use Log::Log4perl::Level;
 use Carp;
 
@@ -96,6 +95,11 @@ sub new {
 
         #whether to collapse arrays, etc.
     $self->{warp_message} = $params{warp_message};
+
+    if (!$INC{'Log/Log4perl/Config.pm'}) {
+        require Log::Log4perl::Config;
+    }
+
     if($self->{warp_message} and
        my $cref = 
        Log::Log4perl::Config::compile_if_perl($self->{warp_message})) {


### PR DESCRIPTION
only require Log::Log4perl::Config if it hasn't already been loaded

Refs #59

This replaces (https://github.com/mschilli/log4perl/pull/80) which I closed by mistake