### PR TITLE
Add AppVeyor config for Windows CI testing

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,15 @@
+branches:
+    only:
+      - master
+      - appveyor-.*
+skip_tags: true
+cache:
+  - C:\strawberry -> .appveyor.yml
+install:
+  - if not exist "C:\strawberry" cinst strawberryperl
+  - set PATH=C:\strawberry\perl\bin;C:\strawberry\perl\site\bin;C:\strawberry\c\bin;%PATH%
+  - cd C:\projects\%APPVEYOR_PROJECT_NAME%
+  - cpanm --verbose --installdeps .
+build_script:
+  - perl Makefile.PL
+  - gmake test


### PR DESCRIPTION
Add a config for AppVeyor. This might help for #77.

You can get a free account with your GitHub credentials.

I've used this with my fork of Log4perl: https://ci.appveyor.com/project/briandfoy/log4perl/history