### PR TITLE
Make it clear that the 'priority' means the 'log level'

### DIFF
--- a/README
+++ b/README
@@ -559,7 +559,7 @@ How to use it
             %m{chomp} The message to be logged, stripped off a trailing newline
             %M Method or function where the logging request was issued
             %n Newline (OS-independent)
-            %p Priority of the logging event
+            %p Priority of the logging event (AKA log level)
             %P pid of the current process
             %r Number of milliseconds elapsed from program start to logging 
                event

--- a/lib/Log/Log4perl/Layout/PatternLayout.pm
+++ b/lib/Log/Log4perl/Layout/PatternLayout.pm
@@ -568,7 +568,7 @@ replaced by the logging engine when it's time to log the message:
     %m{indent=n} Log message, multi-lines indented by n spaces
     %M Method or function where the logging request was issued
     %n Newline (OS-independent)
-    %p Priority of the logging event (%p{1} shows the first letter)
+    %p Priority/level of the logging event (%p{1} shows the first letter)
     %P pid of the current process
     %r Number of milliseconds elapsed from program start to logging 
        event


### PR DESCRIPTION
This was driving me crazy, whenever I grepped the docs for how to specify the log level in the PatternLayout format, I couldn't find it.

Turns out it's called "priority". This change will allow people to more easily find out how to print the "log level" in their logs.
