### PR TITLE
render NAME as non-literal in POD

### DIFF
--- a/lib/Log/Log4perl/Appender/Buffer.pm
+++ b/lib/Log/Log4perl/Appender/Buffer.pm
@@ -140,7 +140,7 @@ __END__
 
 =head1 NAME
 
-    Log::Log4perl::Appender::Buffer - Buffering Appender
+Log::Log4perl::Appender::Buffer - Buffering Appender
 
 =head1 SYNOPSIS
 

--- a/lib/Log/Log4perl/Appender/Limit.pm
+++ b/lib/Log/Log4perl/Appender/Limit.pm
@@ -194,7 +194,7 @@ __END__
 
 =head1 NAME
 
-    Log::Log4perl::Appender::Limit - Limit message delivery via block period
+Log::Log4perl::Appender::Limit - Limit message delivery via block period
 
 =head1 SYNOPSIS
 

--- a/lib/Log/Log4perl/Appender/Synchronized.pm
+++ b/lib/Log/Log4perl/Appender/Synchronized.pm
@@ -97,7 +97,7 @@ __END__
 
 =head1 NAME
 
-    Log::Log4perl::Appender::Synchronized - Synchronizing other appenders
+Log::Log4perl::Appender::Synchronized - Synchronizing other appenders
 
 =head1 SYNOPSIS
 

--- a/lib/Log/Log4perl/Layout/PatternLayout/Multiline.pm
+++ b/lib/Log/Log4perl/Layout/PatternLayout/Multiline.pm
@@ -30,7 +30,7 @@ __END__
 
 =head1 NAME
 
-    Log::Log4perl::Layout::PatternLayout::Multiline
+Log::Log4perl::Layout::PatternLayout::Multiline
 
 =head1 SYNOPSIS
 


### PR DESCRIPTION
This is the style used in the majority of modules in this dist, and cpan in general.