### PR TITLE
NAME in POD incorrect for ScreenColoredLevels

### DIFF
--- a/lib/Log/Log4perl/Appender/ScreenColoredLevels.pm
+++ b/lib/Log/Log4perl/Appender/ScreenColoredLevels.pm
@@ -79,7 +79,7 @@ __END__
 
 =head1 NAME
 
-Log::Log4perl::Appender::ScreenColoredLevel - Colorize messages according to level
+Log::Log4perl::Appender::ScreenColoredLevels - Colorize messages according to level
 
 =head1 SYNOPSIS
 


### PR DESCRIPTION
The NAME in the POD is 'Log::Log4perl::Appender::ScreenColoredLevel' but the module name is 'Log::Log4perl::Appender::ScreenColoredLevels'.  This is only a change of one character, so it's a very simple PR.