### PR TITLE
Fix test failure due to quirk of unlink on Windows

### DIFF
--- a/t/026FileApp.t
+++ b/t/026FileApp.t
@@ -447,6 +447,7 @@ log4perl.appender.Logfile          = Log::Log4perl::Appender::File
 log4perl.appender.Logfile.filename = ${testfile}_5
 log4perl.appender.Logfile.header_text = This is a nice header.
 log4perl.appender.Logfile.syswrite = 1
+log4perl.appender.Logfile.mode=write
 log4perl.appender.Logfile.layout   = Log::Log4perl::Layout::SimpleLayout
 );
 


### PR DESCRIPTION
`unlink` on Windows does not delete the file instantly, and the `Log4perl` default to append, which cause the `t/026FileApp.t` to fail.

This fixes https://github.com/mschilli/log4perl/issues/77