### PR TITLE
Support mixed STDOUT/STDERR in Screen Appenders

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,6 @@
 - fix Appender::File bug on Windows when different volume
-- add autoflush option to Log::Log4perl::Appender::Screen
+- add autoflush option to Log::Log4perl::Appender::Screen - thanks @abraxxa
+- stderr option for Appender::Screen* can take hash - thanks @bmodotdev
 
 1.54 2021-02-06
 - set real versions for some modules - thanks @eserte for report

--- a/lib/Log/Log4perl.pm
+++ b/lib/Log/Log4perl.pm
@@ -2512,6 +2512,12 @@ in Perl, without using a configuration file at all:
                           name      => "screenlog",
                           stderr    => 0);
 
+     # Define a mixed stderr/stdout appender
+  my $mixed_stdout_stderr_appender = Log::Log4perl::Appender->new(
+                          "Log::Log4perl::Appender::Screen",
+                          name      => "screenlog",
+                          stderr    => { ERROR => 1, FATAL => 1 });
+
      # Have both appenders use the same layout (could be different)
   $stdout_appender->layout($layout);
   $file_appender->layout($layout);

--- a/lib/Log/Log4perl/Appender/ScreenColoredLevels.pm
+++ b/lib/Log/Log4perl/Appender/ScreenColoredLevels.pm
@@ -63,12 +63,16 @@ sub log {
     if ( my $color = $self->{ 'color' }->{ $params{ 'log4p_level' } } ) {
         $msg = Term::ANSIColor::colored( $msg, $color );
     }
-    
-    if($self->{stderr}) {
-        print STDERR $msg;
-    } else {
-        print $msg;
+
+    my $fh = \*STDOUT;
+    if (ref $self->{stderr}) {
+        $fh = \*STDERR if $self->{stderr}{ $params{'log4p_level'} }
+                            || $self->{stderr}{ lc $params{'log4p_level'} };
+    } elsif ($self->{stderr}) {
+        $fh = \*STDERR;
     }
+
+    print $fh $msg;
 }
 
 1;
@@ -185,12 +189,27 @@ Red
 =back
 
 The constructor C<new()> takes an optional parameter C<stderr>,
-if set to a true value, the appender will log to STDERR. If C<stderr>
-is set to a false value, it will log to STDOUT. The default setting
-for C<stderr> is 1, so messages will be logged to STDERR by default.
-The constructor can also take an optional parameter C<color>, whose
-value is a  hashref of color configuration options, any levels that
-are not included in the hashref will be set to their default values.
+if set to a true value, the appender will log all levels to STDERR.
+If C<stderr> is set to a false value, it will log all levels to
+STDOUT. Otherwise, C<stderr> may be set to a hash, with a key for
+each C<log4p_level> and a truthy value to dynamically use stderr.
+The default setting for C<stderr> is 1, so all messages will be logged
+to STDERR by default.
+
+    # All messages/levels to STDERR
+    my $app = Log::Log4perl::Appender::Screen->new(
+        stderr  => 1,
+    );
+
+    # Only ERROR and FATAL to STDERR (case-sensitive)
+    my $app = Log::Log4perl::Appender::Screen->new(
+        stderr  => { ERROR => 1, FATAL => 1},
+    );
+
+The constructor can also take an optional
+parameter C<color>, whose value is a  hashref of color configuration
+options, any levels that are not included in the hashref will be set
+to their default values.
 
 =head2 Using ScreenColoredLevels on Windows
 

--- a/t/071ScreenStdoutStderr.t
+++ b/t/071ScreenStdoutStderr.t
@@ -1,0 +1,114 @@
+BEGIN {
+    if($ENV{INTERNAL_DEBUG}) {
+        require Log::Log4perl::InternalDebug;
+        Log::Log4perl::InternalDebug->enable();
+    }
+}
+
+use warnings;
+use strict;
+
+use Log::Log4perl qw(:easy :no_extra_logdie_message);
+use Test::More;
+use File::Spec;
+use lib File::Spec->catdir(qw(t lib));
+use Log4perlInternalTest qw(tmpdir);
+
+BEGIN {
+    if ($] < 5.008) {
+        plan skip_all => "Only with perl >= 5.008";
+    } else {
+        plan tests => 30;
+    }
+}
+
+#########################################################################
+# Capture STDERR to a temporary file and a filehandle to read from it
+
+++$|;
+my $WORK_DIR        = tmpdir();
+my $TMP_FILE_STDOUT = File::Spec->catfile($WORK_DIR, qw(stdout));
+my $TMP_FILE_STDERR = File::Spec->catfile($WORK_DIR, qw(stderr));
+
+open STDOUT, '>', $TMP_FILE_STDOUT;
+open STDERR, '>', $TMP_FILE_STDERR;
+open IN_STDOUT, '<', $TMP_FILE_STDOUT or die "Cannot open $TMP_FILE_STDOUT"; binmode IN_STDOUT, ":utf8";
+open IN_STDERR, '<', $TMP_FILE_STDERR or die "Cannot open $TMP_FILE_STDERR"; binmode IN_STDERR, ":utf8";
+sub readstdout { return join("", <IN_STDOUT>); }
+sub readstderr { return join("", <IN_STDERR>); }
+
+END   { unlink $TMP_FILE_STDOUT;
+        unlink $TMP_FILE_STDERR;
+        close IN_STDOUT;
+        close IN_STDERR;
+}
+#########################################################################
+
+# Tests for all stdout
+my %tests = (
+    debug   => { stderr => 0, code => \&DEBUG   },
+    info    => { stderr => 0, code => \&INFO    },
+    warn    => { stderr => 0, code => \&WARN    },
+    error   => { stderr => 0, code => \&ERROR   },
+    fatal   => { stderr => 0, code => \&FATAL   },
+);
+
+my $conf = qq(
+log4perl.category               = DEBUG, Screen
+
+# Regular Screen Appender
+log4perl.appender.Screen        = Log::Log4perl::Appender::Screen
+log4perl.appender.Screen.layout = Log::Log4perl::Layout::SimpleLayout
+log4perl.appender.Screen.stderr = 0
+);
+
+do_tests( $conf, \%tests );
+
+# Test for all stderr - reset our captures and set stderr to 1
+truncate STDOUT, 0;
+truncate STDERR, 0;
+++$tests{ $_ }{stderr} for (keys %tests);
+
+$conf = qq(
+log4perl.category               = DEBUG, Screen
+
+# Regular Screen Appender
+log4perl.appender.Screen        = Log::Log4perl::Appender::Screen
+log4perl.appender.Screen.layout = Log::Log4perl::Layout::SimpleLayout
+log4perl.appender.Screen.stderr = 1
+);
+
+do_tests( $conf, \%tests );
+
+# Tests for mixed stdout and stderr - reset our captures and set some to stdout
+truncate STDOUT, 0;
+truncate STDERR, 0;
+--$tests{debug}{stderr};
+--$tests{info}{stderr};
+--$tests{warn}{stderr};
+
+$conf = qq(
+log4perl.category                       = DEBUG, Screen
+
+# Regular Screen Appender
+log4perl.appender.Screen                = Log::Log4perl::Appender::Screen
+log4perl.appender.Screen.layout         = Log::Log4perl::Layout::SimpleLayout
+log4perl.appender.Screen.stderr.ERROR   = 1
+# Lower case test
+log4perl.appender.Screen.stderr.fatal   = 1
+);
+
+do_tests( $conf, \%tests );
+
+sub do_tests {
+    my ($conf, $tests) = @_;
+
+    Log::Log4perl->init(\$conf);
+
+    for my $level (sort keys %{ $tests }) {
+        # e.g. "DEBUG('debug')"
+        $tests->{ $level }{code}->( $level );
+        is( readstdout() =~ /$level/ ? 0 : 1, $tests->{ $level }{stderr}, $level . ' to stdout');
+        is( readstderr() =~ /$level/ ? 1 : 0, $tests->{ $level }{stderr}, $level . ' to stderr');
+    }
+}


### PR DESCRIPTION
Currently “Log::Log4perl::Appender::Screen” and “ScreenColoredLevels”
only support sending all levels to STDOUT or STDERR. This adds the
ability to specify only certain log4p_level’s got to STDERR. The
legacy behavior of sending all to STDOUT or STDERR is still supported.