### PR TITLE
readline() now sets eof at end of file, clear it

### DIFF
--- a/t/020Easy.t
+++ b/t/020Easy.t
@@ -43,7 +43,7 @@ unlink $TMP_FILE;
 open STDERR, ">$TMP_FILE";
 select STDERR; $| = 1; #needed on win32
 open IN, "<$TMP_FILE" or die "Cannot open $TMP_FILE";
-sub readstderr { return join("", <IN>); }
+sub readstderr { IN->clearerr(); return join("", <IN>); }
 
 ############################################################
 # Typical easy setup

--- a/t/051Extra.t
+++ b/t/051Extra.t
@@ -48,7 +48,7 @@ my $TMP_FILE = File::Spec->catfile($WORK_DIR, qw(easy));
 open STDERR, ">$TMP_FILE";
 select STDERR; $| = 1; #needed on win32
 open IN, "<$TMP_FILE" or die "Cannot open $TMP_FILE"; binmode IN, ":utf8";
-sub readstderr { return join("", <IN>); }
+sub readstderr { IN->clearerr(); return join("", <IN>); }
 
 END   { unlink $TMP_FILE;
         close IN;

--- a/t/071ScreenStdoutStderr.t
+++ b/t/071ScreenStdoutStderr.t
@@ -34,8 +34,8 @@ open STDOUT, '>', $TMP_FILE_STDOUT;
 open STDERR, '>', $TMP_FILE_STDERR;
 open IN_STDOUT, '<', $TMP_FILE_STDOUT or die "Cannot open $TMP_FILE_STDOUT"; binmode IN_STDOUT, ":utf8";
 open IN_STDERR, '<', $TMP_FILE_STDERR or die "Cannot open $TMP_FILE_STDERR"; binmode IN_STDERR, ":utf8";
-sub readstdout { return join("", <IN_STDOUT>); }
-sub readstderr { return join("", <IN_STDERR>); }
+sub readstdout { IN_STDOUT->clearerr(); return join("", <IN_STDOUT>); }
+sub readstderr { IN_STDERR->clearerr(); return join("", <IN_STDERR>); }
 
 END   { unlink $TMP_FILE_STDOUT;
         unlink $TMP_FILE_STDERR;


### PR DESCRIPTION
80c1f1e in perl 5.37.3 fixed a bug where readline() could clear the stream eof flag right after reading up to end of file.

The log4perl tests depended on this bug, to continue to work, clear the eof flag before trying to continue reading from the redirected stdout/stderr files.