### PR TITLE
Add Mulitple Key/Value Pair to MDC->put and Add Delete Method to MDC

### DIFF
--- a/lib/Log/Log4perl/MDC.pm
+++ b/lib/Log/Log4perl/MDC.pm
@@ -28,15 +28,20 @@ sub get {
 ###########################################
 sub put {
 ###########################################
-    my($class, $key, $value) = @_;
-
-    if($class ne __PACKAGE__) {
-        # Somebody called us with Log::Log4perl::MDC::put($key, $value)
-        $value = $key;
-        $key   = $class;
+	if( $_[0] eq __PACKAGE__ ) {
+        # Somebody called us with Log::Log4perl::MDC->put(...);
+        shift( @_ );
     }
 
-    $MDC_HASH{$key} = $value;
+    my %values = (ref $_[0] eq 'HASH') ?
+                        # called with hashref argument
+                        %{ $_[0] } :
+                        # called with list of key value pairs
+                        @_;
+
+    foreach my $key( keys %values ) {
+        $MDC_HASH{$key} = $values{$key};
+    }
 }
 
 ###########################################
@@ -79,6 +84,15 @@ C<Log::Log4perl::Layout::PatternLayout>s.
 =item Log::Log4perl::MDC->put($key, $value);
 
 Store a value C<$value> under key C<$key> in the map.
+
+=item Log::Log4perl::MDC->put($key1 => $value1, $key2 => $value2);
+
+=item Log::Log4perl::MDC->put({$key1 => $value1, $key2 => $value2});
+
+Store multiple key C<$key#>/value C<$value#> pairs in the map.
+
+NOTE: This diverges from the log4j implementation where only one key/value
+pair can be added at a time.
 
 =item my $value = Log::Log4perl::MDC->get($key);
 

--- a/lib/Log/Log4perl/MDC.pm
+++ b/lib/Log/Log4perl/MDC.pm
@@ -28,7 +28,7 @@ sub get {
 ###########################################
 sub put {
 ###########################################
-	if( $_[0] eq __PACKAGE__ ) {
+    if( $_[0] eq __PACKAGE__ ) {
         # Somebody called us with Log::Log4perl::MDC->put(...);
         shift( @_ );
     }
@@ -42,6 +42,18 @@ sub put {
     foreach my $key( keys %values ) {
         $MDC_HASH{$key} = $values{$key};
     }
+}
+
+###########################################
+sub delete {
+###########################################
+    my( $class, $key ) = @_;
+
+    if( $class ne __PACKAGE__ ) {
+        $key = $class;
+    }
+
+    delete( $MDC_HASH{$key} );
 }
 
 ###########################################
@@ -101,11 +113,19 @@ Typically done by C<%X{key}> in
 C<Log::Log4perl::Layout::PatternLayout>.
 If no value exists to the given key, C<undef> is returned.
 
-=item my $text = Log::Log4perl::MDC->remove();
+=item Log::Log4perl::MDC->delete($key);
+
+Deletes the C<$key> in the context map.
+
+NOTE: In log4j, this is the 'remove' method.
+
+=item Log::Log4perl::MDC->remove();
 
 Delete all entries from the map.
 
-=item Log::Log4perl::MDC->get_context();
+NOTE: In log4j, this is the 'clear' method.
+
+=item my $context = Log::Log4perl::MDC->get_context();
 
 Returns a reference to the hash table.
 
@@ -147,4 +167,3 @@ Grundman, Paul Harrington, Alexander Hartmaier  David Hull,
 Robert Jacobson, Jason Kohles, Jeff Macdonald, Markus Peter, 
 Brett Rann, Peter Rabbitson, Erik Selberg, Aaron Straup Cope, 
 Lars Thegler, David Viner, Mac Yang.
-

--- a/t/072.MDC.t
+++ b/t/072.MDC.t
@@ -1,0 +1,48 @@
+BEGIN { 
+    if($ENV{INTERNAL_DEBUG}) {
+        require Log::Log4perl::InternalDebug;
+        Log::Log4perl::InternalDebug->enable();
+    }
+}  
+
+use strict;
+use warnings;
+
+use Test::More;
+use Log::Log4perl::MDC;
+
+Log::Log4perl::MDC::put('test-one', 'value-one');
+is( Log::Log4perl::MDC::get('test-one'), 
+    'value-one', 
+    'Calling put/get class methods works with colon notation'
+);
+
+Log::Log4perl::MDC->put('test-two', 'value-two');
+is( Log::Log4perl::MDC->get('test-two'),
+    'value-two',
+    'Calling put/get class methods works with arrow notation'
+);
+
+# We have verified both arrow and colon notation work. Sticking
+# with arrow notation from now on.
+
+Log::Log4perl::MDC->put('test-three'          => 'value-three', 
+			'test-three-part-two' => 'value-three-part-two');
+is( Log::Log4perl::MDC->get('test-three') . Log::Log4perl::MDC->get('test-three-part-two'),
+    'value-threevalue-three-part-two',
+    'Calling put with multiple key/value pairs adds all to store'
+);
+
+Log::Log4perl::MDC->put({ 'test-four' => 'value-four',
+			  'test-four-part-two' => 'value-four-part-two' });
+is( Log::Log4perl::MDC->get('test-four') . Log::Log4perl::MDC->get('test-four-part-two'),
+    'value-fourvalue-four-part-two',
+    'Calling put with hashref adds all key/values to store'
+);
+
+is( Log::Log4perl::MDC->get('test-five'), undef, 'Calling get on unknown key returns undef');
+
+Log::Log4perl::MDC->remove();
+is_deeply(Log::Log4perl::MDC->get_context(), {}, 'Calling remove deletes all entries');
+
+done_testing;

--- a/t/072.MDC.t
+++ b/t/072.MDC.t
@@ -42,6 +42,12 @@ is( Log::Log4perl::MDC->get('test-four') . Log::Log4perl::MDC->get('test-four-pa
 
 is( Log::Log4perl::MDC->get('test-five'), undef, 'Calling get on unknown key returns undef');
 
+Log::Log4perl::MDC->delete('test-three');
+is( Log::Log4perl::MDC->get('test-three'),
+    undef,
+    'Calling delete on a key removes from context'
+);
+
 Log::Log4perl::MDC->remove();
 is_deeply(Log::Log4perl::MDC->get_context(), {}, 'Calling remove deletes all entries');
 


### PR DESCRIPTION
Updated Log::Log4perl::MDC module to allow multiple key/value pairs to be 'put' into the context in a single method call and added a way to remove a single key/value pair by name.

Not sure how close this project was trying to stay in step with the log4j project, but 'NOTE's were added to perldoc where functionality strayed.

Fixes the following issues:
#125 
#117 